### PR TITLE
Корректировка расчета скользящей средней частоты

### DIFF
--- a/Semester 1/Hackathon 1/app/core.py
+++ b/Semester 1/Hackathon 1/app/core.py
@@ -148,7 +148,7 @@ def bird_dynamics(df, bird='', longitude_left=-180, longitude_right=180, latitud
 
     df_result['Скользящее среднее (всего)'] = df_result['Общее количество записей'].rolling(3, min_periods=1).mean()
     df_result['Скользящее среднее (вида)'] = df_result['Количество записей вида'].rolling(3, min_periods=1).mean()
-    df_result['Скользящее среднее (частота)'] = df_result['Частота'].rolling(3, min_periods=1).mean()
+    df_result['Скользящее среднее (частота)'] = df_result['Скользящее среднее (вида)'] / df_result['Скользящее среднее (всего)'] * 1000
 
     df_result['Риск вымирания'] = 'Нет данных'
     for i in range(len(df_result)):


### PR DESCRIPTION
Теперь скользящая средняя по частоте считается как скользящая средняя по числу записей по виду птиц деленная на скользящую среднюю по общему числу записей. До этого было - считается как средняя по значениям частоты